### PR TITLE
Split client into annotations and predictions flavors

### DIFF
--- a/butler/annotations/__init__.py
+++ b/butler/annotations/__init__.py
@@ -1,4 +1,5 @@
 from butler.annotations.annotations import Annotations
+from butler.annotations.annotations_client import AnnotationsClient
 from butler.annotations.bbx_utils import butler_bbx_to_min_max
 from butler.annotations.document_annotation_with_image import DocumentAnnotationWithImage
 from butler.annotations.layoutlm_utils import normalize_ner_annotation_for_layoutlm

--- a/butler/annotations/annotations_client.py
+++ b/butler/annotations/annotations_client.py
@@ -1,0 +1,73 @@
+import logging
+from typing import List, Optional
+
+from butler.annotations.annotations import Annotations
+from butler.common.http_utils import verify_response_or_raise
+from butler.generated.api.models import get_model, get_training_document, get_training_documents
+from butler.generated.client import AuthenticatedClient
+from butler.generated.models import (
+    ModelTrainingDocumentStatus,
+    PaginatedTrainingDocumentsDto,
+    TrainingDocumentResultDto,
+)
+
+
+class AnnotationsClient:
+    _client: AuthenticatedClient
+
+    def _get_training_documents(
+        self,
+        model_id: str,
+        after_id: Optional[str],
+        document_status: ModelTrainingDocumentStatus = ModelTrainingDocumentStatus.LABELED,
+    ) -> PaginatedTrainingDocumentsDto:
+        return verify_response_or_raise(
+            get_training_documents.sync_detailed(
+                client=self._client, id=model_id, after_id=after_id, document_status=document_status
+            )
+        )
+
+    def load_annotations(
+        self,
+        model_id: str,
+        load_all_pages: bool = False,
+        document_status: ModelTrainingDocumentStatus = ModelTrainingDocumentStatus.LABELED,
+    ) -> Annotations:
+        """
+        Loads annotations from a model using the Butler API
+        """
+        # First load the model details so the schema can be passed to the Annotations object
+        logging.info("Loading model details")
+        model_details = verify_response_or_raise(get_model.sync_detailed(client=self._client, id=model_id))
+
+        training_docs_list: List[TrainingDocumentResultDto] = []
+
+        should_fetch_more_docs = True
+        after_id = None
+        logging.info("Loading training documents")
+        while should_fetch_more_docs:
+            # Fetch the next batch of training documents
+            training_docs_page = self._get_training_documents(model_id, after_id, document_status=document_status)
+
+            # Get details for each training document, which includes the annotations
+            for training_doc in training_docs_page.items:
+                training_doc_details = verify_response_or_raise(
+                    get_training_document.sync_detailed(
+                        client=self._client,
+                        id=model_id,
+                        document_id=training_doc.document_id,
+                    ),
+                )
+                training_docs_list.append(training_doc_details)
+
+            logging.info("Loaded %d of %d training documents", len(training_docs_list), training_docs_page.total_count)
+
+            # Determine if we should fetch more documents
+            after_id = training_docs_page.items[-1].document_id
+            should_fetch_more_docs = load_all_pages and training_docs_page.has_next
+
+        logging.info("Creating Annotations")
+        return Annotations(
+            model_details=model_details,
+            training_documents=training_docs_list,
+        )

--- a/butler/client.py
+++ b/butler/client.py
@@ -1,112 +1,14 @@
-import logging
-from typing import List, Optional
+from typing import Optional
 
-from butler.annotations.annotations import Annotations
-from butler.generated.api.models import get_model, get_training_document, get_training_documents
-from butler.generated.api.queues import extract_document
+from butler.annotations import AnnotationsClient
 from butler.generated.client import AuthenticatedClient
-from butler.generated.models import (
-    ExtractDocumentMultipartData,
-    ExtractionResultsDto,
-    PaginatedTrainingDocumentsDto,
-    TrainingDocumentResultDto,
-)
-from butler.generated.models.model_training_document_status import ModelTrainingDocumentStatus
-from butler.generated.types import File
-from butler.utils import EmptyJsonBody, infer_file_name, infer_mime_type, verify_response_or_raise
+from butler.predictions import PredictionsClient
 
 
-class Client:
+class Client(PredictionsClient, AnnotationsClient):
     def __init__(self, api_key: str, base_url: Optional[str] = None) -> None:
         self._client = AuthenticatedClient(
             base_url=base_url if base_url is not None else "https://app.butlerlabs.ai",
             token=api_key,
             timeout=60.0,
-        )
-
-    def extract_document(
-        self,
-        queue_id: str,
-        file_path: str,
-        file_name: Optional[str] = None,
-        mime_type: Optional[str] = None,
-    ) -> ExtractionResultsDto:
-        """
-        Uploads a supported file (PDF, PNG, and JPG) to the Butler API and fetches results
-
-        Limitations: Function times out in 30 seconds, works on PDFs of sizes up to 5 pages
-        """
-        with open(file_path, "rb") as f:
-            file_name = file_name if file_name is not None else infer_file_name(f)
-            mime_type = mime_type if mime_type is not None else infer_mime_type(file_name)
-            return verify_response_or_raise(
-                extract_document.sync_detailed(
-                    client=self._client,
-                    queue_id=queue_id,
-                    multipart_data=ExtractDocumentMultipartData(
-                        file=File(
-                            payload=f,
-                            file_name=file_name,
-                            mime_type=mime_type,
-                        ),
-                    ),
-                    json_body=EmptyJsonBody(),
-                )
-            )
-
-    def _get_training_documents(
-        self,
-        model_id: str,
-        after_id: Optional[str],
-        document_status: ModelTrainingDocumentStatus = ModelTrainingDocumentStatus.LABELED,
-    ) -> PaginatedTrainingDocumentsDto:
-        return verify_response_or_raise(
-            get_training_documents.sync_detailed(
-                client=self._client, id=model_id, after_id=after_id, document_status=document_status
-            )
-        )
-
-    def load_annotations(
-        self,
-        model_id: str,
-        load_all_pages: bool = False,
-        document_status: ModelTrainingDocumentStatus = ModelTrainingDocumentStatus.LABELED,
-    ) -> Annotations:
-        """
-        Loads annotations from a model using the Butler API
-        """
-        # First load the model details so the schema can be passed to the Annotations object
-        logging.info("Loading model details")
-        model_details = verify_response_or_raise(get_model.sync_detailed(client=self._client, id=model_id))
-
-        training_docs_list: List[TrainingDocumentResultDto] = []
-
-        should_fetch_more_docs = True
-        after_id = None
-        logging.info("Loading training documents")
-        while should_fetch_more_docs:
-            # Fetch the next batch of training documents
-            training_docs_page = self._get_training_documents(model_id, after_id, document_status=document_status)
-
-            # Get details for each training document, which includes the annotations
-            for training_doc in training_docs_page.items:
-                training_doc_details = verify_response_or_raise(
-                    get_training_document.sync_detailed(
-                        client=self._client,
-                        id=model_id,
-                        document_id=training_doc.document_id,
-                    ),
-                )
-                training_docs_list.append(training_doc_details)
-
-            logging.info("Loaded %d of %d training documents", len(training_docs_list), training_docs_page.total_count)
-
-            # Determine if we should fetch more documents
-            after_id = training_docs_page.items[-1].document_id
-            should_fetch_more_docs = load_all_pages and training_docs_page.has_next
-
-        logging.info("Creating Annotations")
-        return Annotations(
-            model_details=model_details,
-            training_documents=training_docs_list,
         )

--- a/butler/common/file_utils.py
+++ b/butler/common/file_utils.py
@@ -1,0 +1,15 @@
+import mimetypes
+import os
+from io import FileIO
+
+
+# Utils for inferring file name and mime type for a local file
+def infer_file_name(f: FileIO) -> str:
+    return os.path.basename(f.name)
+
+
+def infer_mime_type(file_name: str) -> str:
+    mime_type = mimetypes.guess_type(file_name)[0]
+    if mime_type is None:
+        raise RuntimeError(f"could not infer mime type for file {file_name}, please specify mime type manually")
+    return mime_type

--- a/butler/common/http_utils.py
+++ b/butler/common/http_utils.py
@@ -1,7 +1,4 @@
 import json
-import mimetypes
-import os
-from io import FileIO
 from typing import TypeVar
 
 from butler.generated.types import Response
@@ -26,22 +23,3 @@ def verify_response_or_raise(response: Response[T]) -> T:
             message = e.get("message") if isinstance(e, dict) else None
         finally:
             raise HttpException(response.status_code, message or "unknown error")
-
-
-# Utils for inferring file name and mime type for a local file
-def infer_file_name(f: FileIO) -> str:
-    return os.path.basename(f.name)
-
-
-def infer_mime_type(file_name: str) -> str:
-    mime_type = mimetypes.guess_type(file_name)[0]
-    if mime_type is None:
-        raise RuntimeError(f"could not infer mime type for file {file_name}, please specify mime type manually")
-    return mime_type
-
-
-# Empty class for bypassing improper codegen for cases that have
-# both multipart/form-data and application/json requests
-class EmptyJsonBody:
-    def to_dict(self):
-        return {}

--- a/butler/common/types.py
+++ b/butler/common/types.py
@@ -1,0 +1,5 @@
+# Empty class for bypassing improper codegen for cases that have
+# both multipart/form-data and application/json requests
+class EmptyJsonBody:
+    def to_dict(self):
+        return {}

--- a/butler/predictions/__init__.py
+++ b/butler/predictions/__init__.py
@@ -1,0 +1,2 @@
+from butler.generated.models import ExtractionResultsDto
+from butler.predictions.predictions_client import PredictionsClient

--- a/butler/predictions/predictions_client.py
+++ b/butler/predictions/predictions_client.py
@@ -1,0 +1,43 @@
+from typing import Optional
+
+from butler.common.file_utils import infer_file_name, infer_mime_type
+from butler.common.http_utils import verify_response_or_raise
+from butler.common.types import EmptyJsonBody
+from butler.generated.api.queues import extract_document
+from butler.generated.client import AuthenticatedClient
+from butler.generated.models import ExtractDocumentMultipartData, ExtractionResultsDto
+from butler.generated.types import File
+
+
+class PredictionsClient:
+    _client: AuthenticatedClient
+
+    def extract_document(
+        self,
+        queue_id: str,
+        file_path: str,
+        file_name: Optional[str] = None,
+        mime_type: Optional[str] = None,
+    ) -> ExtractionResultsDto:
+        """
+        Uploads a supported file (PDF, PNG, and JPG) to the Butler API and fetches results
+
+        Limitations: Function times out in 30 seconds, works on PDFs of sizes up to 5 pages
+        """
+        with open(file_path, "rb") as f:
+            file_name = file_name if file_name is not None else infer_file_name(f)
+            mime_type = mime_type if mime_type is not None else infer_mime_type(file_name)
+            return verify_response_or_raise(
+                extract_document.sync_detailed(
+                    client=self._client,
+                    queue_id=queue_id,
+                    multipart_data=ExtractDocumentMultipartData(
+                        file=File(
+                            payload=f,
+                            file_name=file_name,
+                            mime_type=mime_type,
+                        ),
+                    ),
+                    json_body=EmptyJsonBody(),
+                )
+            )

--- a/butler/test/test_extract_document.py
+++ b/butler/test/test_extract_document.py
@@ -1,0 +1,22 @@
+import logging
+import os
+
+from butler import Client
+from butler.annotations.layoutlm_utils import normalize_ner_annotation_for_layoutlm
+
+# Run using 'python -m butler.test.test_extract_document'
+
+logging.basicConfig(level=logging.INFO)
+
+# Get API Key from https://docs.butlerlabs.ai/reference/uploading-documents-to-the-rest-api#get-your-api-key
+api_key = os.environ["BUTLER_API_KEY"]
+
+# Find your queue's uuid
+queue_id = "00000000-0000-0000-0000-000000000000"
+
+# Get a local test file
+local_file = "path/to/file"
+
+extraction_results = Client(api_key).extract_document(queue_id, local_file)
+
+print(extraction_results)

--- a/butler/test/test_load_annotations.py
+++ b/butler/test/test_load_annotations.py
@@ -4,7 +4,7 @@ import os
 from butler import Client
 from butler.annotations.layoutlm_utils import normalize_ner_annotation_for_layoutlm
 
-# Run using 'python -m butler.test_load_annotations'
+# Run using 'python -m butler.test.test_load_annotations'
 
 logging.basicConfig(level=logging.INFO)
 


### PR DESCRIPTION
Split client implementation into multiple pieces so that we are not implementing everything directly in client.py.

Instead we have:
- PredictionsClient in butler.predictions module
- AnnotationsClient in butler.annotations module
- For ease of use, the Client just brings together the various pieces and initializes the lower level AuthenticatedClient

Additionally, if users did want to reference the return types, they should be able to get them from the appropriate packages now, without having to import from the generated codegen module:
- from butler.annotations import Annotations
- from butler.predictions import ExtractionResultsDto

Also create a butler.common folder to house shared types, utils, etc.